### PR TITLE
Add support of types.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.3",
   "description": "Tiny eventing for javascript",
   "main": "dist/minivents.commonjs.js",
+  "types": "./typings/minievents.d.ts",
   "browser": "dist/minivents.commonjs.min.js",
   "scripts": {
     "test": "gulp test",

--- a/types/minievents.d.ts
+++ b/types/minievents.d.ts
@@ -1,0 +1,35 @@
+/**
+ * Add support of events to class.
+ */
+export class Events {
+    /**
+     * Listen to events.
+     *
+     * @param type
+     * @param callback
+     * @param context
+     */
+    on(type: string, callback: Function, context: any[])
+
+    /**
+     * Stop listening to events or specific callback.
+     *
+     * @param type
+     * @param callback
+     */
+    off(type: string = null, callback: Function = null)
+
+    /**
+     * Send event. Callbacks will be triggered.
+     *
+     * @param type
+     */
+    emit(type: string)
+}
+
+/**
+ * Can
+ * @param object
+ * @constructor
+ */
+export function Events<T>(object: T): T & Events;

--- a/types/minievents.d.ts
+++ b/types/minievents.d.ts
@@ -28,8 +28,8 @@ export class Events {
 }
 
 /**
- * Can
+ * Add support of events to object.
+ *
  * @param object
- * @constructor
  */
 export function Events<T>(object: T): T & Events;


### PR DESCRIPTION
These type definitions will help with TypeScript.

For example:
```javascript
import {Events} from "minievents";

// Function:
class Person {
    age: number = 100;
}
let person = Events<Person>(new Person());
person.age = 10;
person.emit('example');

// Inheritance:
class Cat extends Events {
    mew(){
        this.emit('mew');
    }
}
```