### PR TITLE
Fix `types` field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minivents",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Tiny eventing for javascript",
   "main": "dist/minivents.commonjs.js",
   "types": "./types/minievents.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.2.0",
   "description": "Tiny eventing for javascript",
   "main": "dist/minivents.commonjs.js",
-  "types": "./typings/minievents.d.ts",
+  "types": "./types/minievents.d.ts",
   "browser": "dist/minivents.commonjs.min.js",
   "scripts": {
     "test": "gulp test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minivents",
-  "version": "2.3.1",
+  "version": "2.2.0",
   "description": "Tiny eventing for javascript",
   "main": "dist/minivents.commonjs.js",
   "types": "./types/minievents.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minivents",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Tiny eventing for javascript",
   "main": "dist/minivents.commonjs.js",
   "types": "./types/minievents.d.ts",

--- a/types/minievents.d.ts
+++ b/types/minievents.d.ts
@@ -17,7 +17,7 @@ export class Events {
      * @param type
      * @param callback
      */
-    off(type: string = null, callback: Function = null)
+    off(type?: string, callback?: Function)
 
     /**
      * Send event. Callbacks will be triggered.


### PR DESCRIPTION
The `types` field point to a `typings` folder while it's actually named `types`.