### PR TITLE
Various TypeScript definition fixes

### DIFF
--- a/types/minievents.d.ts
+++ b/types/minievents.d.ts
@@ -29,10 +29,19 @@ interface EventEmitter {
 }
 
 /**
- * Add event handling capabilities to an object.
- *
+ * Add event handling capabilities to an object or create a new event emitter.
+ * Can be used both as a function and as a constructor.
+ * 
  * @param target Object to add event handling to (optional - defaults to this)
  */
 declare function Events<T extends object = {}>(target?: T): T & EventEmitter;
+
+declare namespace Events {
+    interface EventsConstructor {
+        new (): EventEmitter;
+    }
+}
+
+interface Events extends Events.EventsConstructor {}
 
 export = Events;

--- a/types/minievents.d.ts
+++ b/types/minievents.d.ts
@@ -29,19 +29,17 @@ interface EventEmitter {
 }
 
 /**
- * Add event handling capabilities to an object or create a new event emitter.
- * Can be used both as a function and as a constructor.
+ * Events can be used both as a function and as a constructor. 
+ * When used as a function, it mixes event handling capabilities into the provided target. 
+ * When used as a constructor, it creates a new event emitter.
  * 
  * @param target Object to add event handling to (optional - defaults to this)
  */
-declare function Events<T extends object = {}>(target?: T): T & EventEmitter;
-
-declare namespace Events {
-    interface EventsConstructor {
-        new (): EventEmitter;
-    }
+interface EventsInterface {
+    <T extends object = {}>(target?: T): T & EventEmitter;
+    new (): EventEmitter;
 }
 
-interface Events extends Events.EventsConstructor {}
+declare const Events: EventsInterface;
 
 export = Events;

--- a/types/minievents.d.ts
+++ b/types/minievents.d.ts
@@ -1,35 +1,38 @@
 /**
- * Add support of events to class.
+ * Interface for objects with event handling capabilities
  */
-export class Events {
+interface EventEmitter {
     /**
      * Listen to events.
      *
-     * @param type
-     * @param callback
-     * @param context
+     * @param type Event type
+     * @param func Callback function
+     * @param ctx Context for the callback
      */
-    on(type: string, callback: Function, context: any[])
+    on(type: string, func: Function, ctx?: any): this;
 
     /**
-     * Stop listening to events or specific callback.
+     * Stop listening to event / specific callback.
      *
-     * @param type
-     * @param callback
+     * @param type Event type (optional - if not provided, removes all events)
+     * @param func Specific callback to remove (optional)
      */
-    off(type?: string, callback?: Function)
+    off(type?: string, func?: Function): this;
 
     /**
-     * Send event. Callbacks will be triggered.
+     * Send event, callbacks will be triggered.
      *
-     * @param type
+     * @param type Event type
+     * @param args Additional arguments to pass to callbacks
      */
-    emit(type: string)
+    emit(type: string, ...args: any[]): this;
 }
 
 /**
- * Add support of events to object.
+ * Add event handling capabilities to an object.
  *
- * @param object
+ * @param target Object to add event handling to (optional - defaults to this)
  */
-export function Events<T>(object: T): T & Events;
+declare function Events<T extends object = {}>(target?: T): T & EventEmitter;
+
+export = Events;

--- a/types/minievents.d.ts
+++ b/types/minievents.d.ts
@@ -1,7 +1,7 @@
 /**
  * Interface for objects with event handling capabilities
  */
-interface EventEmitter {
+interface Events {
     /**
      * Listen to events.
      *
@@ -35,11 +35,11 @@ interface EventEmitter {
  * 
  * @param target Object to add event handling to (optional - defaults to this)
  */
-interface EventsInterface {
-    <T extends object = {}>(target?: T): T & EventEmitter;
-    new (): EventEmitter;
+interface EventsConstructor {
+    <T extends object = {}>(target?: T): T & Events;
+    new (): Events;
 }
 
-declare const Events: EventsInterface;
+declare const Events: EventsConstructor;
 
 export = Events;


### PR DESCRIPTION
This stopped typescript complaining about:
- calling `new Events`
- using `Events` as a type
- chaining
- additional arguments on `emit`